### PR TITLE
chore: Add ECDSA test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683235108,
-        "narHash": "sha256-2NN/pb9hwM5/qJ5mpJfGso1H3fc2RRaZ4sZhVPvT0Dw=",
+        "lastModified": 1683639407,
+        "narHash": "sha256-TyjeCb0pqpQbteYCxXGtIOMz+8d0U450FBAGZ3gZOB0=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "e66f1ef38c3c87c223456d8a77878c2bd3d346eb",
+        "rev": "bb08dfa2134a00fbc91b38c8cdb0be868a523c1c",
         "type": "github"
       },
       "original": {

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -776,9 +776,9 @@ mod test {
         // Constrain the result to be true
         let mut constraints = Vec::new();
         let result_constraint = Constraint {
-            a: result_index as i32,
-            b: result_index as i32,
-            c: result_index as i32,
+            a: result_index,
+            b: result_index,
+            c: result_index,
             qm: FieldElement::zero(),
             ql: FieldElement::one(),
             qr: FieldElement::zero(),


### PR DESCRIPTION
This adds a test for EcDSA secp256k1 -- The test vectors were taken from barretenberg. See the `generate_ecdsa_constraints` in the DSL module.