### PR TITLE
Change verify function visibility from external to public to enable inheritance

### DIFF
--- a/src/acvm_interop/contract.sol
+++ b/src/acvm_interop/contract.sol
@@ -299,7 +299,7 @@ abstract contract BaseUltraVerifier {
      * @param _publicInputs - An array of the public inputs
      * @return True if proof is valid, reverts otherwise
      */
-    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool) {
+    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) public view returns (bool) {
         loadVerificationKey(N_LOC, OMEGA_INVERSE_LOC);
 
         uint256 requiredPublicInputCount;


### PR DESCRIPTION
## The problem

It should be common for devs to inherit from `UltraVerifier` while creating a dApp. This is to keep the codebase organized and readable. A normal implementation should look like the following example:

```solidity
//SPDX-License-Identifier: MIT
pragma solidity >=0.8.19;

contract MyDApp is UltraVerifier {
    // Custom logic
    function proveStuff(bytes calldata _proof, bytes32[] calldata _publicInputs) public {
        verify(_proof, _publicInputs));
        // More custom logic
    }
}
```

However this is currently not possible due to the `verify` function being `external`. This means that this function is not visible to inherited contracts.

## The solution

I think the `verify` visibility should be changed to `public`. This will enable `verify` being called from inherited contracts like the example above.