### PR TITLE
fix: Add description so crate can be published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "acvm-backend-barretenberg"
+description = "An ACVM backend which allows proving/verifying ACIR circuits against Aztec Lab's Barretenberg library."
 version = "0.1.0"
 authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aztec_backend
 
-This is a backend for the [ACVM](https://github.com/noir-lang/acvm) which allows proving/verifying ACIR circuits against Aztec Protocol's [Barretenberg](https://github.com/AztecProtocol/barretenberg) library.
+An [ACVM](https://github.com/noir-lang/acvm) backend which allows proving/verifying ACIR circuits against Aztec Lab's [Barretenberg](https://github.com/AztecProtocol/barretenberg) library.
 
 ## Working on this project
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Build the Barretenberg acvm backend";
+  description = "An ACVM backend which allows proving/verifying ACIR circuits against Aztec Lab's Barretenberg library.";
 
   inputs = {
     nixpkgs = {


### PR DESCRIPTION
This adds a description to the crate so it can be published. Published of 0.1.0 failed at https://github.com/noir-lang/acvm-backend-barretenberg/actions/runs/4943022200/jobs/8837108338