### PR TITLE
fix: Remove star dependencies to allow publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ indicatif = { version = "0.17.3", optional = true }
 barretenberg-sys = { version = "0.1.2", optional = true }
 
 # Wasm
-wasmer = { version = "*", optional = true, default-features = false }
+wasmer = { version = "2.3", optional = true, default-features = false }
 rust-embed = { version = "6.6.0", optional = true, features = [
     "debug-embed",
     "interpolate-folder-path",
@@ -40,7 +40,7 @@ pkg-config = "0.3"
 
 [dev-dependencies]
 sled = "0.34.6"
-tempfile = "*"
+tempfile = "3.3"
 
 [features]
 default = ["native"]


### PR DESCRIPTION
Cargo publish failed because of the `*` deps in the toml file.