### PR TITLE
chore: Add logic to parse manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,7 @@ dependencies = [
  "ark-bn254 0.3.0",
  "ark-ec 0.3.0",
  "ark-ff 0.3.0",
- "ark-poly 0.3.0",
  "ark-serialize 0.3.0",
- "ark-std 0.3.0",
  "barretenberg-sys",
  "blake2",
  "dirs 3.0.2",
@@ -162,6 +160,7 @@ dependencies = [
  "ark-std 0.3.0",
  "derivative",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -172,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly 0.4.2",
+ "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -196,6 +195,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "rayon",
  "rustc_version 0.3.3",
  "zeroize",
 ]
@@ -267,19 +267,6 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
@@ -297,7 +284,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
- "ark-serialize-derive 0.3.0",
  "ark-std 0.3.0",
  "digest 0.9.0",
 ]
@@ -308,21 +294,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive 0.4.2",
+ "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.6",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -344,6 +319,7 @@ checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
  "rand",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,8 +20,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a267ef529f4b132293199ecdf8c232ade817f01d916039f2d34562cab39e75e9"
 dependencies = [
- "ark-bn254",
- "ark-ff",
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.2",
  "cfg-if",
  "hex",
  "num-bigint",
@@ -52,6 +52,12 @@ name = "acvm-backend-barretenberg"
 version = "0.1.2"
 dependencies = [
  "acvm",
+ "ark-bn254 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "barretenberg-sys",
  "blake2",
  "dirs 3.0.2",
@@ -125,13 +131,38 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+dependencies = [
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
+dependencies = [
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -140,10 +171,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools",
@@ -153,22 +184,50 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.6",
  "itertools",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.4.0",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -177,6 +236,18 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "quote",
  "syn",
 ]
@@ -196,15 +267,39 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
+dependencies = [
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-serialize-derive 0.3.0",
+ "ark-std 0.3.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -213,10 +308,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
  "digest 0.10.6",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -228,6 +334,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -1604,6 +1720,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,11 +2121,20 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -2068,9 +2203,27 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2453,6 +2606,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,16 @@ pkg-config = "0.3"
 [dev-dependencies]
 sled = "0.34.6"
 tempfile = "3.3"
+# arkworks CRS test
+ark-ec = { version = "0.3", default-features = false }
+ark-serialize = { version = "0.3", default-features = false }
+ark-poly = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-bn254 = "^0.3.0"
+ark-std = "^0.3.0"
 
 [features]
-default = ["native"]
+default = ["wasm"]
 native = [
     "dep:barretenberg-sys",
     "dep:reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,11 @@ pkg-config = "0.3"
 [dev-dependencies]
 sled = "0.34.6"
 tempfile = "3.3"
-# arkworks CRS test
-ark-ec = { version = "0.3", default-features = false }
-ark-serialize = { version = "0.3", default-features = false }
-ark-poly = { version = "^0.3.0", default-features = false }
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-bn254 = "^0.3.0"
-ark-std = "^0.3.0"
+
+ark-ec = { version = "0.3", features = ["parallel"] }
+ark-serialize = { version = "0.3" }
+ark-ff = { version = "^0.3.0", features = ["parallel", "asm"] }
+ark-bn254 = { version = "^0.3.0" }
 
 [features]
 default = ["wasm"]

--- a/src/crs.rs
+++ b/src/crs.rs
@@ -28,7 +28,7 @@ fn transcript_location(transcript_number: u16) -> PathBuf {
 /// Example: `100` will map to transcript100.dat
 ///
 /// TODO: Add smoke tests for this
-fn transcript_number_to_filename(transcript_number: u16) -> String {
+pub(crate) fn transcript_number_to_filename(transcript_number: u16) -> String {
     format!("transcript{:0>2}.dat", transcript_number.to_string())
 }
 

--- a/src/crs_parse.rs
+++ b/src/crs_parse.rs
@@ -58,12 +58,6 @@ struct Manifest {
     start_from: u32,
 }
 
-#[derive(Debug)]
-pub enum CRSError {
-    IO(std::io::Error),
-    NotEnoughPoints { need: u32 },
-}
-
 impl Manifest {
     /// Returns the number of bytes needed to encode the `Manifest`
     fn size() -> u64 {
@@ -152,12 +146,11 @@ impl CRS {
     /// and stores those points in the CRS.
     ///
     /// If the `degree` is too much, then a `NotEnoughPoints` error is returned.
-    pub(crate) fn from_raw_dir<P: AsRef<Path>>(path: P, degree: u32) -> Result<CRS, CRSError> {
+    pub(crate) fn from_raw_dir<P: AsRef<Path>>(path: P, degree: u32) -> std::io::Result<CRS> {
         let path_to_transcript00 = path.as_ref().join(TRANSCRIPT_FILES[0]);
-        let (g1_points, remaining) =
-            Self::parse_g1_points(&path_to_transcript00, degree).map_err(CRSError::IO)?;
+        let (g1_points, remaining) = Self::parse_g1_points(&path_to_transcript00, degree)?;
 
-        let g2_point = Self::parse_g2_point(path_to_transcript00).map_err(CRSError::IO)?;
+        let g2_point = Self::parse_g2_point(path_to_transcript00)?;
 
         Ok(CRS {
             g1_points,

--- a/src/crs_parse.rs
+++ b/src/crs_parse.rs
@@ -1,0 +1,297 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Read;
+use std::path::Path;
+
+const TRANSCRIPT_FILES: [&str; 1] = ["transcript00.dat"];
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SerializedFq([u64; 4]);
+
+impl SerializedFq {
+    /// Returns the number of bytes needed to encode a
+    /// Fq field element in bytes
+    pub(crate) fn size_in_bytes() -> u64 {
+        32
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SerializedG1Affine {
+    x: SerializedFq,
+    y: SerializedFq,
+}
+
+impl SerializedG1Affine {
+    /// Returns the number of bytes needed to encode a
+    /// a G1 affine point.
+    pub(crate) fn size_in_bytes() -> u64 {
+        SerializedFq::size_in_bytes() * 2
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SerializedFq2 {
+    c0: SerializedFq,
+    c1: SerializedFq,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SerializedG2Affine {
+    x: SerializedFq2,
+    y: SerializedFq2,
+}
+
+pub(crate) struct CRS {
+    pub g1_points: Vec<SerializedG1Affine>,
+    pub g2_point: SerializedG2Affine,
+}
+
+#[derive(Debug)]
+struct Manifest {
+    transcript_number: u32,
+    total_transcripts: u32,
+    total_g1_points: u32,
+    total_g2_points: u32,
+    num_g1_points: u32,
+    num_g2_points: u32,
+    start_from: u32,
+}
+
+#[derive(Debug)]
+pub enum CRSError {
+    IO(std::io::Error),
+    NotEnoughPoints { need: u32 },
+}
+
+impl Manifest {
+    /// Returns the number of bytes needed to encode the `Manifest`
+    fn size() -> u64 {
+        let num_fields_in_struct = 7;
+        let size_of_each_field_in_bytes = 32 / 8;
+
+        num_fields_in_struct * size_of_each_field_in_bytes
+    }
+    /// Reads `Manifest` from the given file
+    fn read_from_file(reader: &mut BufReader<File>) -> std::io::Result<Manifest> {
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let transcript_number = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let total_transcripts = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let total_g1_points = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let total_g2_points = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let num_g1_points = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let num_g2_points = u32::from_be_bytes(bytes);
+
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let start_from = u32::from_be_bytes(bytes);
+
+        Ok(Manifest {
+            transcript_number,
+            total_transcripts,
+            total_g1_points,
+            total_g2_points,
+            num_g1_points,
+            num_g2_points,
+            start_from,
+        })
+    }
+}
+
+impl CRS {
+    /// Reads `degree` number of points from the file at `path`
+    /// and stores those points in the CRS.
+    ///
+    /// If the `degree` is too much, then a `NotEnoughPoints` error is returned.
+    pub(crate) fn from_raw_dir<P: AsRef<Path>>(path: P, degree: u32) -> Result<CRS, CRSError> {
+        let path_to_transcript00 = path.as_ref().join(TRANSCRIPT_FILES[0]);
+        let file_to_transcript00 = File::open(&path_to_transcript00).map_err(CRSError::IO)?;
+        let mut reader = BufReader::new(file_to_transcript00);
+
+        let manifest = Manifest::read_from_file(&mut reader).map_err(CRSError::IO)?;
+
+        // if manifest.num_g1_points < degree {
+        //     return Err(CRSError::NotEnoughPoints {
+        //         need: degree - manifest.num_g1_points,
+        //     });
+        // }
+        let g1_points = CRS::read_serialized_g1_points(&mut reader, degree);
+
+        let mut file_to_transcript00 = File::open(path_to_transcript00).map_err(CRSError::IO)?;
+        use std::io::{Seek, SeekFrom};
+
+        let g2_offset = SerializedG1Affine::size_in_bytes() * manifest.num_g1_points as u64;
+
+        file_to_transcript00
+            .seek(SeekFrom::Start(g2_offset + Manifest::size()))
+            .map_err(CRSError::IO)?;
+        let mut reader = BufReader::new(file_to_transcript00);
+        let g2_point = CRS::read_serialized_g2_point(&mut reader);
+
+        Ok(CRS {
+            g1_points,
+            g2_point,
+        })
+    }
+
+    /// Reads `degree` number of G1 Points from the transcript
+    fn read_serialized_g1_points(
+        reader: &mut BufReader<File>,
+        degree: u32,
+    ) -> Vec<SerializedG1Affine> {
+        let mut g1_points = Vec::with_capacity(degree as usize);
+
+        for _ in 0..degree {
+            let x_limbs = read_limbs(reader);
+            let y_limbs = read_limbs(reader);
+
+            let point = SerializedG1Affine {
+                x: SerializedFq(x_limbs),
+                y: SerializedFq(y_limbs),
+            };
+            g1_points.push(point);
+        }
+        g1_points
+    }
+
+    fn read_serialized_g2_point(reader: &mut impl Read) -> SerializedG2Affine {
+        let x_c0_limbs = read_limbs(reader);
+        let x_c1_limbs = read_limbs(reader);
+
+        let y_c0_limbs = read_limbs(reader);
+        let y_c1_limbs = read_limbs(reader);
+
+        let x = SerializedFq2 {
+            c0: SerializedFq(x_c0_limbs),
+            c1: SerializedFq(x_c1_limbs),
+        };
+        let y = SerializedFq2 {
+            c0: SerializedFq(y_c0_limbs),
+            c1: SerializedFq(y_c1_limbs),
+        };
+        SerializedG2Affine { x, y }
+    }
+}
+
+// Read four u64s into a slice from a reader
+// limbs are not in montgomery form
+fn read_limbs(reader: &mut impl Read) -> [u64; 4] {
+    let mut limbs = [0u64; 4];
+    for limb in limbs.iter_mut() {
+        let mut bytes = [0u8; 8];
+        reader.read_exact(&mut bytes).unwrap();
+        *limb = u64::from_be_bytes(bytes);
+    }
+    limbs
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_bn254::{Fq, Fq2, G1Affine, G2Affine};
+    use ark_ff::{BigInteger256, PrimeField};
+
+    use crate::crs::download_crs;
+
+    use super::{SerializedG1Affine, SerializedG2Affine, CRS};
+
+    // Convert the limbs into montgomery form
+    // and then a field element
+    fn limbs_to_field_element(limbs: [u64; 4]) -> Fq {
+        Fq::from_repr(BigInteger256::new(limbs)).unwrap()
+    }
+
+    struct ArkCRS {
+        g1_points: Vec<G1Affine>,
+        g2_point: G2Affine,
+    }
+
+    impl ArkCRS {
+        fn from_raw_crs(crs: CRS) -> Self {
+            Self {
+                g1_points: to_arkworks_points_g1(&crs.g1_points),
+                g2_point: to_arkworks_point_g2(crs.g2_point),
+            }
+        }
+    }
+
+    fn to_arkworks_points_g1(points: &[SerializedG1Affine]) -> Vec<G1Affine> {
+        let mut ark_points = Vec::new();
+
+        for point in points {
+            let ark_x = limbs_to_field_element(point.x.0);
+            let ark_y = limbs_to_field_element(point.y.0);
+            ark_points.push(G1Affine::new(ark_x, ark_y, false))
+        }
+        ark_points
+    }
+    fn to_arkworks_point_g2(point: SerializedG2Affine) -> G2Affine {
+        let ark_x_c0 = limbs_to_field_element(point.x.c0.0);
+        let ark_x_c1 = limbs_to_field_element(point.x.c1.0);
+        let x = Fq2::new(ark_x_c0, ark_x_c1);
+
+        let ark_y_c0 = limbs_to_field_element(point.y.c0.0);
+        let ark_y_c1 = limbs_to_field_element(point.y.c1.0);
+        let y = Fq2::new(ark_y_c0, ark_y_c1);
+
+        G2Affine::new(x, y, false)
+    }
+    #[test]
+    fn read_crs() {
+        use ark_bn254::Bn254;
+        use ark_ec::AffineCurve;
+        use ark_ec::PairingEngine;
+        use ark_ff::One;
+
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+
+        let dir_path = dir.path().to_path_buf();
+        let file_path = dir_path.join("transcript00.dat");
+        let res = download_crs(file_path, 0);
+        assert!(res.is_ok());
+
+        let crs = CRS::from_raw_dir(dir_path, 1_000).unwrap();
+        let crs = ArkCRS::from_raw_crs(crs);
+        for point in &crs.g1_points {
+            assert!(point.is_on_curve());
+            assert!(point.is_in_correct_subgroup_assuming_on_curve())
+        }
+        let ark_g2 = crs.g2_point;
+        assert!(ark_g2.is_on_curve());
+        assert!(ark_g2.is_in_correct_subgroup_assuming_on_curve());
+
+        let p0 = -crs.g1_points[1]; // -xG
+        let p1 = crs.g1_points[0]; // G
+        let q0 = G2Affine::prime_subgroup_generator(); // Q
+        let q1 = crs.g2_point; // xQ
+
+        // e(-xG, Q) * e(G, xQ)
+        // e(-xG, Q) * e(xG, Q)
+        // e( xG - xG, Q)
+        // e(0*G, Q)
+        // = 1
+        let res1 = Bn254::pairing(p0, q0);
+        let res2 = Bn254::pairing(p1, q1);
+        let res = res1 * res2;
+        assert!(res.is_one());
+
+        let res = Bn254::product_of_pairings(&vec![(p0.into(), q0.into()), (p1.into(), q1.into())]);
+        assert!(res.is_one());
+    }
+}

--- a/src/crs_parse.rs
+++ b/src/crs_parse.rs
@@ -72,8 +72,8 @@ impl Manifest {
 
         num_fields_in_struct * size_of_each_field_in_bytes
     }
-    /// Reads `Manifest` from the given file
-    fn read_from_file(reader: &mut impl Read) -> std::io::Result<Manifest> {
+    /// Reads `Manifest` from the given `Reader`
+    fn read(reader: &mut impl Read) -> std::io::Result<Manifest> {
         let mut bytes = [0u8; 4];
         reader.read_exact(&mut bytes)?;
         let transcript_number = u32::from_be_bytes(bytes);
@@ -121,7 +121,7 @@ impl CRS {
     ) -> std::io::Result<(Vec<SerializedG1Affine>, u32)> {
         let file_to_transcript = File::open(&path_to_transcript)?;
         let mut reader = BufReader::new(&file_to_transcript);
-        let manifest = Manifest::read_from_file(&mut reader)?;
+        let manifest = Manifest::read(&mut reader)?;
         let g1_points = CRS::read_serialized_g1_points(&mut reader, num_points);
 
         let remaining_points = if manifest.num_g1_points < num_points {
@@ -138,7 +138,7 @@ impl CRS {
     ) -> std::io::Result<SerializedG2Affine> {
         let mut file_to_transcript = File::open(&path_to_first_transcript)?;
         let mut reader = BufReader::new(&file_to_transcript);
-        let manifest = Manifest::read_from_file(&mut reader)?;
+        let manifest = Manifest::read(&mut reader)?;
 
         use std::io::{Seek, SeekFrom};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod barretenberg_structures;
 mod composer;
 #[cfg(any(feature = "native", feature = "wasm"))]
 mod crs;
+mod crs_parse;
 #[cfg(test)]
 mod merkle;
 mod pedersen;


### PR DESCRIPTION
Currently a rough draft;

- If we do not want to test the transcript, we can make the logic a lot simpler by copying opaque bytes and deleting the structures. -- This will remove the arkworks dependency, but means we will not know whether the transcript is valid.

- The test will take a long time if the amount of points is set to > 5.1M , we can speed this up by parsing serialized points into arkworks points using rayon