### PR TITLE
chore: Remove streaming CRS download & indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,8 @@ dependencies = [
  "barretenberg-sys",
  "bincode",
  "blake2",
- "bytes",
- "futures-util",
+ "bytesize",
  "getrandom",
- "indicatif",
  "pkg-config",
  "reqwest",
  "rust-embed",
@@ -415,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bytesize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,19 +475,6 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
-]
-
-[[package]]
-name = "console"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -775,12 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,23 +898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
-name = "futures-io"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,14 +916,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1199,18 +1162,6 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
  "serde",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -1487,12 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,12 +1520,6 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
-
-[[package]]
-name = "portable-atomic"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1818,12 +1757,10 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -2570,19 +2507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmer"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,21 +2847,6 @@ dependencies = [
  "windows_i686_msvc 0.33.0",
  "windows_x86_64_gnu 0.33.0",
  "windows_x86_64_msvc 0.33.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 acvm = { version = "0.11.0", features = ["bn254"] }
-
-thiserror = "1.0.21"
-serde = { version = "1.0.136", features = ["derive"] }
 bincode = "1.3.3"
 bytesize = "1.2"
-
-reqwest = { version = "0.11.16", optional = true, default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
+serde = { version = "1.0.136", features = ["derive"] }
+thiserror = "1.0.21"
 
 # Native
 barretenberg-sys = { version = "0.1.2", optional = true }
@@ -41,8 +39,7 @@ tokio = { version = "1.0", features = [ "macros" ] }
 [features]
 default = ["native"]
 native = [
-    "dep:barretenberg-sys",
-    "dep:reqwest"
+    "dep:barretenberg-sys"
 ]
 wasm = [
     "wasmer",
@@ -52,8 +49,7 @@ wasm = [
     "wasmer/cranelift",
     "wasmer/default-compiler",
     "wasmer/default-cranelift",
-    "wasmer/default-universal",
-    "dep:reqwest"
+    "wasmer/default-universal"
 ]
 js = [
     "wasmer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,9 @@ acvm = { version = "0.11.0", features = ["bn254"] }
 thiserror = "1.0.21"
 serde = { version = "1.0.136", features = ["derive"] }
 bincode = "1.3.3"
-bytes = "1.4"
+bytesize = "1.2"
 
-reqwest = { version = "0.11.16", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
-futures-util = { version = "0.3.14", optional = true }
-indicatif = { version = "0.17.3", optional = true }
+reqwest = { version = "0.11.16", optional = true, default-features = false, features = ["rustls-tls"] }
 
 # Native
 barretenberg-sys = { version = "0.1.2", optional = true }
@@ -44,9 +42,7 @@ tokio = { version = "1.0", features = [ "macros" ] }
 default = ["native"]
 native = [
     "dep:barretenberg-sys",
-    "dep:reqwest",
-    "dep:futures-util",
-    "dep:indicatif"
+    "dep:reqwest"
 ]
 wasm = [
     "wasmer",
@@ -57,9 +53,7 @@ wasm = [
     "wasmer/default-compiler",
     "wasmer/default-cranelift",
     "wasmer/default-universal",
-    "dep:reqwest",
-    "dep:futures-util",
-    "dep:indicatif"
+    "dep:reqwest"
 ]
 js = [
     "wasmer",

--- a/cspell.json
+++ b/cspell.json
@@ -73,7 +73,7 @@
         "acir",
         "acvm",
         "barretenberg",
-        "indicatif",
+        "bytesize",
         "wasmer",
         "getrandom"
     ]

--- a/src/crs.rs
+++ b/src/crs.rs
@@ -101,7 +101,7 @@ async fn download(start: usize, end: usize) -> Result<Vec<u8>, CRSError> {
         url: transcript_url.to_string(),
     })?;
 
-    // TODO: We probably want to consider an injectable logger so we can have logging in JS
+    // TODO(#195): We probably want to consider an injectable logger so we can have logging in JS
     println!(
         "\nDownloading the Ignite SRS ({})",
         ByteSize(total_size).to_string_as(false)


### PR DESCRIPTION
This removes the streaming download of the CRS bytes and removes the indicator about how much is downloaded.

Since we are now adjusting our download on circuit size (and growing the CRS as a circuit grows), the backend will no longer be downloading 307mb in one single download. This was making the indicator go from 0 to complete instantly, which looks strange.

Additionally, this sets us up to use the same download function both natively and in JS.