### PR TITLE
feat: Add serde to `ConstraintSystem` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "serde",
+ "serde-big-array",
  "thiserror",
  "tokio",
  "wasmer",
@@ -1965,6 +1966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3.3"
 bytesize = "1.2"
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0.136", features = ["derive"] }
+serde-big-array = "0.5.1"
 thiserror = "1.0.21"
 
 # Native

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -3,10 +3,12 @@ use acvm::acir::circuit::{Circuit, Opcode};
 use acvm::acir::native_types::Expression;
 use acvm::acir::BlackBoxFunc;
 use acvm::FieldElement;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
 
 use crate::Error;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub(crate) struct Assignments(Vec<FieldElement>);
 
 // This is a separate impl so the constructor can get the wasm_bindgen macro in the future
@@ -51,7 +53,7 @@ impl From<Vec<FieldElement>> for Assignments {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct Constraint {
     pub(crate) a: i32,
     pub(crate) b: i32,
@@ -112,7 +114,7 @@ impl Constraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct RangeConstraint {
     pub(crate) a: i32,
     pub(crate) num_bits: i32,
@@ -128,9 +130,11 @@ impl RangeConstraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct EcdsaConstraint {
     pub(crate) hashed_message: Vec<i32>,
+    // Required until Serde adopts const generics: https://github.com/serde-rs/serde/issues/1937
+    #[serde(with = "BigArray")]
     pub(crate) signature: [i32; 64],
     pub(crate) public_key_x: [i32; 32],
     pub(crate) public_key_y: [i32; 32],
@@ -170,9 +174,11 @@ impl EcdsaConstraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct SchnorrConstraint {
     pub(crate) message: Vec<i32>,
+    // Required until Serde adopts const generics: https://github.com/serde-rs/serde/issues/1937
+    #[serde(with = "BigArray")]
     pub(crate) signature: [i32; 64],
     pub(crate) public_key_x: i32,
     pub(crate) public_key_y: i32,
@@ -202,7 +208,7 @@ impl SchnorrConstraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct ComputeMerkleRootConstraint {
     pub(crate) hash_path: Vec<i32>,
     pub(crate) leaf: i32,
@@ -229,7 +235,7 @@ impl ComputeMerkleRootConstraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct Sha256Constraint {
     pub(crate) inputs: Vec<(i32, i32)>,
     pub(crate) result: [i32; 32],
@@ -255,7 +261,7 @@ impl Sha256Constraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct Blake2sConstraint {
     pub(crate) inputs: Vec<(i32, i32)>,
     pub(crate) result: [i32; 32],
@@ -281,7 +287,7 @@ impl Blake2sConstraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct HashToFieldConstraint {
     pub(crate) inputs: Vec<(i32, i32)>,
     pub(crate) result: i32,
@@ -304,7 +310,7 @@ impl HashToFieldConstraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct Keccak256Constraint {
     pub(crate) inputs: Vec<(i32, i32)>,
     pub(crate) result: [i32; 32],
@@ -331,7 +337,7 @@ impl Keccak256Constraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct PedersenConstraint {
     pub(crate) inputs: Vec<i32>,
     pub(crate) result_x: i32,
@@ -354,7 +360,7 @@ impl PedersenConstraint {
         buffer
     }
 }
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct FixedBaseScalarMulConstraint {
     pub(crate) scalar: i32,
     pub(crate) pubkey_x: i32,
@@ -373,7 +379,7 @@ impl FixedBaseScalarMulConstraint {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct LogicConstraint {
     pub(crate) a: i32,
     pub(crate) b: i32,
@@ -415,7 +421,7 @@ impl LogicConstraint {
     }
 }
 
-#[derive(Clone, Hash, Debug, Default)]
+#[derive(Clone, Hash, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct ConstraintSystem {
     var_num: u32,
     public_inputs: Vec<u32>,
@@ -659,7 +665,7 @@ impl ConstraintSystem {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct MemOpBarretenberg {
     pub(crate) is_store: i8,
     pub(crate) index: Constraint,
@@ -677,7 +683,7 @@ impl MemOpBarretenberg {
     }
 }
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct BlockConstraint {
     pub(crate) init: Vec<Constraint>,
     pub(crate) trace: Vec<MemOpBarretenberg>,


### PR DESCRIPTION
This adds serde to all of the ConstraintSystem types. These types being serializable is necessary for running JS tests in a worker thread.