### PR TITLE
fix: Allow async functions without send on async trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.12.0"
-source = "git+https://github.com/noir-lang/acvm?rev=94d5d20e1eb985cb15eb27556bbe8654172c6a1a#94d5d20e1eb985cb15eb27556bbe8654172c6a1a"
+source = "git+https://github.com/noir-lang/acvm?rev=9f9fc216a6d09ca97352ffd365bfd347e94ad8eb#9f9fc216a6d09ca97352ffd365bfd347e94ad8eb"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.12.0"
-source = "git+https://github.com/noir-lang/acvm?rev=94d5d20e1eb985cb15eb27556bbe8654172c6a1a#94d5d20e1eb985cb15eb27556bbe8654172c6a1a"
+source = "git+https://github.com/noir-lang/acvm?rev=9f9fc216a6d09ca97352ffd365bfd347e94ad8eb#9f9fc216a6d09ca97352ffd365bfd347e94ad8eb"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,7 +30,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.12.0"
-source = "git+https://github.com/noir-lang/acvm?rev=94d5d20e1eb985cb15eb27556bbe8654172c6a1a#94d5d20e1eb985cb15eb27556bbe8654172c6a1a"
+source = "git+https://github.com/noir-lang/acvm?rev=9f9fc216a6d09ca97352ffd365bfd347e94ad8eb#9f9fc216a6d09ca97352ffd365bfd347e94ad8eb"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.12.0"
-source = "git+https://github.com/noir-lang/acvm?rev=94d5d20e1eb985cb15eb27556bbe8654172c6a1a#94d5d20e1eb985cb15eb27556bbe8654172c6a1a"
+source = "git+https://github.com/noir-lang/acvm?rev=9f9fc216a6d09ca97352ffd365bfd347e94ad8eb#9f9fc216a6d09ca97352ffd365bfd347e94ad8eb"
 dependencies = [
  "acir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ js = [
 ]
 
 [patch.crates-io]
-acvm = { git = "https://github.com/noir-lang/acvm", rev = "94d5d20e1eb985cb15eb27556bbe8654172c6a1a" }
+acvm = { git = "https://github.com/noir-lang/acvm", rev = "9f9fc216a6d09ca97352ffd365bfd347e94ad8eb" }

--- a/src/acvm_interop/common_reference_string.rs
+++ b/src/acvm_interop/common_reference_string.rs
@@ -3,7 +3,7 @@ use acvm::{acir::circuit::Circuit, async_trait, CommonReferenceString};
 use crate::{composer::Composer, BackendError, Barretenberg};
 
 // TODO(#185): Ensure CRS download works in JS
-#[async_trait]
+#[async_trait(?Send)]
 impl CommonReferenceString for Barretenberg {
     type Error = BackendError;
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -6,7 +6,7 @@ use crate::{crs::CRS, Barretenberg, Error, FIELD_BYTES};
 
 const NUM_RESERVED_GATES: u32 = 4; // this must be >= num_roots_cut_out_of_vanishing_polynomial (found under prover settings in barretenberg)
 
-#[async_trait]
+#[async_trait(?Send)]
 pub(crate) trait Composer {
     fn get_circuit_size(&self, constraint_system: &ConstraintSystem) -> Result<u32, Error>;
 


### PR DESCRIPTION
As noted in https://github.com/noir-lang/acvm/pull/292, the JS implementation does not implement the `Send` trait, so this allows our async code to not implement.