### PR TITLE
chore: add wasm fields to `Barretenberg` with `js` flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,9 @@ const FIELD_BYTES: usize = 32;
 
 #[derive(Debug)]
 pub struct Barretenberg {
-    #[cfg(feature = "wasm")]
+    #[cfg(not(feature = "native"))]
     memory: wasmer::Memory,
-    #[cfg(feature = "wasm")]
+    #[cfg(not(feature = "native"))]
     instance: wasmer::Instance,
 }
 


### PR DESCRIPTION
We currently only add these fields with the `wasm` feature flag but we also need it for the `js` flag. We then always include these if we're not using the native barretenberg.