### PR TITLE
chore: Headless browser testing with wasmer 3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "serde-big-array",
  "thiserror",
  "tokio",
+ "wasm-bindgen-test",
  "wasmer",
 ]
 
@@ -480,6 +481,16 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1221,9 +1232,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1930,6 +1941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,9 +2454,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2447,16 +2464,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
@@ -2485,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2497,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2507,22 +2524,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e636f3a428ff62b3742ebc3c70e254dfe12b8c2b469d688ea59cdd4abcf502"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18c1fad2f7c4958e7bcce014fa212f59a65d5e3721d0f77e6c0b27ede936ba3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ pkg-config = "0.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.0", features = [ "macros" ] }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.36"
+
 [features]
 default = ["native"]
 native = [

--- a/flake.nix
+++ b/flake.nix
@@ -73,27 +73,11 @@
 
       craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-      wasm-bindgen-cli = craneLib.buildPackage rec {
-        pname = "wasm-bindgen-cli";
-        version = "0.2.86";
-
-        src = pkgs.fetchCrate {
-          inherit pname version;
-          sha256 = "sha256-56EOiLbdgAcoTrkyvB3t9TjtLaRvGxFUXx4haLwE2QY=";
+      wasm-bindgen-cli = pkgs.callPackage ./wasm-bindgen-cli.nix {
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = rustToolchain;
+          cargo = rustToolchain;
         };
-
-        nativeBuildInputs = [
-          pkgs.pkg-config
-        ];
-
-        buildInputs = [
-          pkgs.openssl
-        ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-          pkgs.curl
-          pkgs.darwin.apple_sdk.frameworks.Security
-        ];
-
-        doCheck = false;
       };
 
       sharedEnvironment = {

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,11 @@
         BARRETENBERG_BIN_DIR = "${pkgs.barretenberg-wasm}/bin";
       };
 
+      headlessEnvironment = if system != "aarch64-linux" then {
+        CHROMEDRIVER="${pkgs.chromedriver}/bin/chromedriver";
+        WASM_BINDGEN_TEST_TIMEOUT = "3000";
+      } else {};
+
       # We use `include_str!` macro to embed the solidity verifier template so we need to create a special
       # source filter to include .sol files in addition to usual rust/cargo source files
       solidityFilter = path: _type: builtins.match ".*sol$" path != null;
@@ -248,11 +253,8 @@
       # Setup the environment to match the stdenv from `nix build` & `nix flake check`, and
       # combine it with the environment settings, the inputs from our checks derivations,
       # and extra tooling via `nativeBuildInputs`
-      devShells.default = pkgs.mkShell.override { inherit stdenv; } (nativeEnvironment // wasmEnvironment // {
+      devShells.default = pkgs.mkShell.override { inherit stdenv; } (nativeEnvironment // wasmEnvironment // headlessEnvironment // {
         inputsFrom = builtins.attrValues checks;
-
-        CHROMEDRIVER="${pkgs.chromedriver}/bin/chromedriver";
-        WASM_BINDGEN_TEST_TIMEOUT = "3000";
 
         nativeBuildInputs = with pkgs; [
           wasm-bindgen-cli

--- a/src/acvm_interop/smart_contract.rs
+++ b/src/acvm_interop/smart_contract.rs
@@ -78,7 +78,13 @@ impl SmartContract for Barretenberg {
 #[cfg(test)]
 mod tests {
     use acvm::SmartContract;
+    #[cfg(not(target_arch = "wasm32"))]
     use tokio::test;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_worker);
 
     use crate::BackendError;
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -407,7 +407,13 @@ fn prepend_public_inputs(proof: Vec<u8>, public_inputs: Assignments) -> Vec<u8> 
 #[cfg(test)]
 mod test {
     use acvm::FieldElement;
+    #[cfg(not(target_arch = "wasm32"))]
     use tokio::test;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_worker);
 
     use super::*;
     use crate::barretenberg_structures::{

--- a/src/crs.rs
+++ b/src/crs.rs
@@ -135,7 +135,13 @@ pub(crate) async fn download_crs(num_points: usize) -> Result<CRS, Error> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_arch = "wasm32"))]
     use tokio::test;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_worker);
 
     use crate::{crs::download_crs, Error};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,12 +440,12 @@ mod wasm {
                     Ok(_) => {
                         0_i32 // __WASI_ESUCCESS
                     }
-                    Err(err) => {
+                    Err(_) => {
                         29_i32 // __WASI_EIO
                     }
                 }
             }
-            Err(err) => {
+            Err(_) => {
                 29_i32 // __WASI_EIO
             }
         }

--- a/wasm-bindgen-cli.nix
+++ b/wasm-bindgen-cli.nix
@@ -1,0 +1,37 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, nodejs
+, pkg-config
+, openssl
+, stdenv
+, curl
+, darwin
+, runCommand
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wasm-bindgen-cli";
+  version = "0.2.86";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-56EOiLbdgAcoTrkyvB3t9TjtLaRvGxFUXx4haLwE2QY=";
+  };
+
+  cargoSha256 = "sha256-4CPBmz92PuPN6KeGDTdYPAf5+vTFk9EN5Cmx4QJy6yI=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ curl darwin.apple_sdk.frameworks.Security ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://rustwasm.github.io/docs/wasm-bindgen/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    description = "Facilitating high-level interactions between wasm modules and JavaScript";
+    maintainers = with maintainers; [ nitsky rizary ];
+    mainProgram = "wasm-bindgen";
+  };
+}


### PR DESCRIPTION
This sets up the project to run tests in a headless browser when compiled to the `wasm32` target.

I still haven't figured out how to run the headless browser tests inside `nix flake check` but you can run these locally in a nix direnv using `cargo test --no-default-features --target wasm32-unknown-unknown --release`. Note that you'll need chrome installed on your computer otherwise the chromedriver will fail to find a browser.

Not all the tests have been switched to the `wasm_bindgen_test` macro, but the important ones should be successful.