### PR TITLE
feat!: Adds an empty KeccakVar opcode

### DIFF
--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -312,6 +312,36 @@ impl Keccak256Constraint {
 }
 
 #[derive(Clone, Hash, Debug, Serialize, Deserialize)]
+pub(crate) struct Keccak256VarConstraint {
+    pub(crate) inputs: Vec<(i32, i32)>,
+    pub(crate) result: [i32; 32],
+    pub(crate) var_message_size: i32,
+}
+
+impl Keccak256VarConstraint {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+
+        let inputs_len = self.inputs.len() as u32;
+        buffer.extend_from_slice(&inputs_len.to_be_bytes());
+        for constraint in self.inputs.iter() {
+            buffer.extend_from_slice(&constraint.0.to_be_bytes());
+            buffer.extend_from_slice(&constraint.1.to_be_bytes());
+        }
+
+        let result_len = self.result.len() as u32;
+        buffer.extend_from_slice(&result_len.to_be_bytes());
+        for constraint in self.result.iter() {
+            buffer.extend_from_slice(&constraint.to_be_bytes());
+        }
+
+        buffer.extend_from_slice(&self.var_message_size.to_be_bytes());
+
+        buffer
+    }
+}
+
+#[derive(Clone, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct PedersenConstraint {
     pub(crate) inputs: Vec<i32>,
     pub(crate) result_x: i32,
@@ -408,6 +438,7 @@ pub(crate) struct ConstraintSystem {
     blake2s_constraints: Vec<Blake2sConstraint>,
     block_constraints: Vec<BlockConstraint>,
     keccak_constraints: Vec<Keccak256Constraint>,
+    keccak_var_constraints: Vec<Keccak256VarConstraint>,
     pedersen_constraints: Vec<PedersenConstraint>,
     hash_to_field_constraints: Vec<HashToFieldConstraint>,
     fixed_base_scalar_mul_constraints: Vec<FixedBaseScalarMulConstraint>,
@@ -584,6 +615,13 @@ impl ConstraintSystem {
             buffer.extend(&constraint.to_bytes());
         }
 
+        // Serialize each Keccak Var constraint
+        let keccak_var_len = self.keccak_var_constraints.len() as u32;
+        buffer.extend_from_slice(&keccak_var_len.to_be_bytes());
+        for constraint in self.keccak_var_constraints.iter() {
+            buffer.extend(&constraint.to_bytes());
+        }
+
         // Serialize each Pedersen constraint
         let pedersen_len = self.pedersen_constraints.len() as u32;
         buffer.extend_from_slice(&pedersen_len.to_be_bytes());
@@ -707,6 +745,7 @@ impl TryFrom<&Circuit> for ConstraintSystem {
         let mut blake2s_constraints: Vec<Blake2sConstraint> = Vec::new();
         let mut block_constraints: Vec<BlockConstraint> = Vec::new();
         let mut keccak_constraints: Vec<Keccak256Constraint> = Vec::new();
+        let keccak_var_constraints: Vec<Keccak256VarConstraint> = Vec::new();
         let mut pedersen_constraints: Vec<PedersenConstraint> = Vec::new();
         let mut schnorr_constraints: Vec<SchnorrConstraint> = Vec::new();
         let mut ecdsa_secp256k1_constraints: Vec<EcdsaConstraint> = Vec::new();
@@ -1055,6 +1094,7 @@ impl TryFrom<&Circuit> for ConstraintSystem {
             hash_to_field_constraints,
             constraints,
             fixed_base_scalar_mul_constraints,
+            keccak_var_constraints,
         })
     }
 }


### PR DESCRIPTION
The KeccakVar PR in barretenberg was merged in too fast and so we need to include it for serialization to work when we remove the merkle opcode.