### PR TITLE
fix!: update pedersen hashes for new implementation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683909802,
-        "narHash": "sha256-2CL8NYKLYwwy6n0RyldvH86ULgrSvfzHrgq2Qf0ZUkE=",
+        "lastModified": 1685019724,
+        "narHash": "sha256-QWsYyrOda1u0qAQVifybjdibeP6NCWzk4cJ2mtrzA2E=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "97c9bc72aebab850b4a647d6e6cc50085226eafb",
+        "rev": "ad282152836f5e3a5c8f34256b29bdea9d16b854",
         "type": "github"
       },
       "original": {

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -750,7 +750,7 @@ mod test {
             qr: FieldElement::zero(),
             qo: FieldElement::zero(),
             qc: -FieldElement::from_hex(
-                "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",
+                "0x0c5e1ddecd49de44ed5e5798d3f6fb7c71fe3d37f5bee8664cf88a445b5ba0af",
             )
             .unwrap(),
         };
@@ -763,7 +763,7 @@ mod test {
             qr: FieldElement::zero(),
             qo: FieldElement::zero(),
             qc: -FieldElement::from_hex(
-                "0x0ecf9d98be4597a88c46a7e0fa8836b57a7dcb41ee30f8d8787b11cc259c83fa",
+                "0x230294a041e26fe80b827c2ef5cb8784642bbaa83842da2714d62b1f3c4f9752",
             )
             .unwrap(),
         };

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -317,7 +317,7 @@ fn basic_interop_initial_root() {
     // Test that the initial root is computed correctly
     let tree: MerkleTree<blake2::Blake2s256, Barretenberg> = MerkleTree::new(3);
     // Copied from barretenberg by copying the stdout from MemoryTree
-    let expected_hex = "04ccfbbb859b8605546e03dcaf41393476642859ff7f99446c054b841f0e05c8";
+    let expected_hex = "1d25fbc28027b3a24fe36f23228e686113b85e9a1bc3dab3f2fa9f1bba07e3ff";
     assert_eq!(tree.root().to_hex(), expected_hex)
 }
 
@@ -334,12 +334,12 @@ fn basic_interop_hashpath() {
             "1cdcf02431ba623767fe389337d011df1048dcc24b98ed81cec97627bab454a0",
         ),
         (
-            "0b5e9666e7323ce925c28201a97ddf4144ac9d148448ed6f49f9008719c1b85b",
-            "0b5e9666e7323ce925c28201a97ddf4144ac9d148448ed6f49f9008719c1b85b",
+            "04f4ebf549cd40d5203de93ec52710f1c824d591b22df9b5bf57d7c91c7fb5b9",
+            "04f4ebf549cd40d5203de93ec52710f1c824d591b22df9b5bf57d7c91c7fb5b9",
         ),
         (
-            "22ec636f8ad30ef78c42b7fe2be4a4cacf5a445cfb5948224539f59a11d70775",
-            "22ec636f8ad30ef78c42b7fe2be4a4cacf5a445cfb5948224539f59a11d70775",
+            "036313886e80ea10f447a764c2ef19bee046b5224ab10fedb8ccb7e5e90949a9",
+            "036313886e80ea10f447a764c2ef19bee046b5224ab10fedb8ccb7e5e90949a9",
         ),
     ];
 
@@ -364,7 +364,7 @@ fn basic_interop_update() -> Result<(), Error> {
     let root = tree.update_message(7, &[7; 64])?;
 
     assert_eq!(
-        "0ef8e14db4762ebddadb23b2225f93ca200a4c9bd37130b4d028c971bbad16b5",
+        "17ed5d9d4325b280ebe0181b023094633cd07266b076da6463c9624f06148330",
         root.to_hex()
     );
 
@@ -376,12 +376,12 @@ fn basic_interop_update() -> Result<(), Error> {
             "12dc36b01cbd8a6248b04e08f0ec91aa6d11a91f030b4a7b1460281859942185",
         ),
         (
-            "1f399ea0d6aaf602c7cbcb6ae8cda0e6b6487836c017163888ed4fd38b548389",
-            "220dd1b310caa4a6af755b4c893d956c48f31642b487164b258f2973aac2c28f",
+            "130424d5e7941e8d6bbe214ad7826131c533977fc5bc643e28aa9f9330c5cc80",
+            "1ce73b272388269603a8756df36982cbfe994530b6e1f2a0be847048a3e6e0ac",
         ),
         (
-            "25cbb3084647221ffcb535945bb65bd70e0809834dc7a6d865a3f2bb046cdc29",
-            "2cc463fc8c9a4eda416f3e490876672f644708dd0330a915f6835d8396fa8f20",
+            "1f1890817667f873b1fe565ee29a314a86284e02e85bc28dced0e574a34eb826",
+            "143bd7e4e1f13d8f79361b173ace22103c5a880d327b1128e3e91a11bd5976f1",
         ),
     ];
 

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -145,17 +145,17 @@ fn basic_interop() -> Result<(), Error> {
         Test {
             input_left: FieldElement::zero(),
             input_right: FieldElement::one(),
-            expected_hex: "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",
+            expected_hex: "0x0c5e1ddecd49de44ed5e5798d3f6fb7c71fe3d37f5bee8664cf88a445b5ba0af",
         },
         Test {
             input_left: FieldElement::one(),
             input_right: FieldElement::one(),
-            expected_hex: "0x1044a769e185fcdf077c8289a6bf87c5c77ff9561cab69d39fadd90a07ee4af4",
+            expected_hex: "0x0e1793a0c122887bcb53c84776f4704c26bc093b25eaa9c7847a672c65e314ae",
         },
         Test {
             input_left: FieldElement::one(),
             input_right: FieldElement::zero(),
-            expected_hex: "0x17d213c8fe83e89a2f3190933d437a3e231124e0383e6dc6a7b6e6358833e427",
+            expected_hex: "0x0c93b3f27730b2e331e634af15bc9d5a769688921f30b36ca926b35a96b3306c",
         },
     ];
 
@@ -176,11 +176,11 @@ fn pedersen_hash_to_point() -> Result<(), Error> {
     let barretenberg = Barretenberg::new();
     let (x, y) = barretenberg.encrypt(vec![FieldElement::zero(), FieldElement::one()])?;
     let expected_x = FieldElement::from_hex(
-        "0x11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef",
+        "0x0c5e1ddecd49de44ed5e5798d3f6fb7c71fe3d37f5bee8664cf88a445b5ba0af",
     )
     .unwrap();
     let expected_y = FieldElement::from_hex(
-        "0x0ecf9d98be4597a88c46a7e0fa8836b57a7dcb41ee30f8d8787b11cc259c83fa",
+        "0x230294a041e26fe80b827c2ef5cb8784642bbaa83842da2714d62b1f3c4f9752",
     )
     .unwrap();
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*
Pedersen implementation changed in https://github.com/AztecProtocol/barretenberg/pull/414/files#diff-3efc25f3b79f11be68c59e48ae56e83dbd6f38a4c0505e2e3f5ddb3297b7c520
<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

## Summary\*
Pointing barretenberg to this commit https://github.com/AztecProtocol/barretenberg/commit/ad282152836f5e3a5c8f34256b29bdea9d16b854 and updated the pedersen tests
<!-- Describe the changes in this PR, particularly breaking changes if any. -->

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
