### PR TITLE
fix: Add `lib` crate-type to build 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 acvm = { version = "0.12.0", features = ["bn254"] }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

In the [Noir PR](https://github.com/noir-lang/noir/pull/1393) that integrates acvm-0.13.0 updates there was a blocker where `acvm-backend-barretenberg` was not being found. 

I followed the hack mentioned in this issue (https://github.com/rust-lang/cargo/issues/4881). That includes an extra `crate-type`. However, I this most likely blows up the size of the binary that is created. And I noticed that cargo added a flag a few months ago to specify the crate type (https://github.com/rust-lang/cargo/issues/10083). Should we update our manifest and flake on the Noir repo to handle this @phated ?

I pushed this PR to test the Noir CI with the new dep: [acvm-0.13.0-dbg](https://github.com/noir-lang/noir/tree/acvm-0.13.0-dbg). I will push this branch as a PR on the Noir repo once the final CI passes and a couple other updates are reconciled.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
