### PR TITLE
feat!: Update to target ACVM 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a686d2e9e57b6ab9a6e4fb9b8ae16f589dd6002597f9c18990213f2627e4656e"
+checksum = "adf51cc323e2a96e381859e6ea26c14fb94cabe72353a4e2bcc2df582110927b"
 dependencies = [
  "acir_field",
  "brillig_vm",
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7cef2443400feb687cc3c9ac710c81e45dda495a7d4b33acf51ccb39d64fb27"
+checksum = "b1c386958918fac40ec59ba165c1efaf3ee8a25a7b9587794dc88736a67f08db"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a21697700d8b47eab9cd1fb24a5465aab6b50c30dece17f08ebad077ec3c08"
+checksum = "0be8cf5e532200abd879e0e9a1aecfea6605387bc7fdbf3e6c51e4d3799e760e"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "218b068da8e83af7dba9dbc0881013b034f7a24257b5dd86c4390d95cde067ea"
+checksum = "89789ea350d87aeaed31cde2d655a3dbb861a71f1bbed41802e0f8c6a207f11c"
 dependencies = [
  "acir",
 ]
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c4384c6e10aa275904f66b5243d604990ef6fcc693fd9a03596c6c7a51c759"
+checksum = "60857c63a6da410360fca5f98162452561e42dbdff66a6206626b9bf3bb2a4ca"
 dependencies = [
  "acir_field",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-acvm = { version = "0.14.0", features = ["bn254"] }
+acvm = { version = "0.15.0", features = ["bn254"] }
 bincode = "1.3.3"
 bytesize = "1.2"
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -94,11 +94,7 @@ impl PartialWitnessGenerator for Barretenberg {
             dbg!("signature has failed to verify");
         }
 
-        insert_value(
-            initial_witness,
-            *output,
-            FieldElement::from(valid_signature),
-        );
+        insert_value(output, FieldElement::from(valid_signature), initial_witness);
         Ok(OpcodeResolution::Solved)
     }
 
@@ -118,8 +114,8 @@ impl PartialWitnessGenerator for Barretenberg {
         let (res_x, res_y) = self.encrypt(scalars, domain_separator).map_err(|err| {
             OpcodeResolutionError::BlackBoxFunctionFailed(BlackBoxFunc::Pedersen, err.to_string())
         })?;
-        insert_value(initial_witness, outputs[0], res_x);
-        insert_value(initial_witness, outputs[1], res_y);
+        insert_value(&outputs[0], res_x, initial_witness);
+        insert_value(&outputs[1], res_y, initial_witness);
         Ok(OpcodeResolution::Solved)
     }
 
@@ -138,8 +134,8 @@ impl PartialWitnessGenerator for Barretenberg {
             )
         })?;
 
-        insert_value(initial_witness, outputs[0], pub_x);
-        insert_value(initial_witness, outputs[1], pub_y);
+        insert_value(&outputs[0], pub_x, initial_witness);
+        insert_value(&outputs[1], pub_y, initial_witness);
         Ok(OpcodeResolution::Solved)
     }
 }

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -94,7 +94,7 @@ impl PartialWitnessGenerator for Barretenberg {
             dbg!("signature has failed to verify");
         }
 
-        insert_value(output, FieldElement::from(valid_signature), initial_witness);
+        insert_value(output, FieldElement::from(valid_signature), initial_witness)?;
         Ok(OpcodeResolution::Solved)
     }
 
@@ -114,8 +114,8 @@ impl PartialWitnessGenerator for Barretenberg {
         let (res_x, res_y) = self.encrypt(scalars, domain_separator).map_err(|err| {
             OpcodeResolutionError::BlackBoxFunctionFailed(BlackBoxFunc::Pedersen, err.to_string())
         })?;
-        insert_value(&outputs[0], res_x, initial_witness);
-        insert_value(&outputs[1], res_y, initial_witness);
+        insert_value(&outputs[0], res_x, initial_witness)?;
+        insert_value(&outputs[1], res_y, initial_witness)?;
         Ok(OpcodeResolution::Solved)
     }
 
@@ -134,8 +134,8 @@ impl PartialWitnessGenerator for Barretenberg {
             )
         })?;
 
-        insert_value(&outputs[0], pub_x, initial_witness);
-        insert_value(&outputs[1], pub_y, initial_witness);
+        insert_value(&outputs[0], pub_x, initial_witness)?;
+        insert_value(&outputs[1], pub_y, initial_witness)?;
         Ok(OpcodeResolution::Solved)
     }
 }

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -1,7 +1,7 @@
 use acvm::acir::circuit::opcodes::FunctionInput;
 use acvm::acir::native_types::{Witness, WitnessMap};
 use acvm::acir::BlackBoxFunc;
-use acvm::pwg::{witness_to_value, OpcodeResolution, OpcodeResolutionError};
+use acvm::pwg::{insert_value, witness_to_value, OpcodeResolution, OpcodeResolutionError};
 use acvm::{FieldElement, PartialWitnessGenerator};
 
 use crate::pedersen::Pedersen;
@@ -94,7 +94,11 @@ impl PartialWitnessGenerator for Barretenberg {
             dbg!("signature has failed to verify");
         }
 
-        initial_witness.insert(*output, FieldElement::from(valid_signature));
+        insert_value(
+            initial_witness,
+            *output,
+            FieldElement::from(valid_signature),
+        );
         Ok(OpcodeResolution::Solved)
     }
 
@@ -114,8 +118,8 @@ impl PartialWitnessGenerator for Barretenberg {
         let (res_x, res_y) = self.encrypt(scalars, domain_separator).map_err(|err| {
             OpcodeResolutionError::BlackBoxFunctionFailed(BlackBoxFunc::Pedersen, err.to_string())
         })?;
-        initial_witness.insert(outputs[0], res_x);
-        initial_witness.insert(outputs[1], res_y);
+        insert_value(initial_witness, outputs[0], res_x);
+        insert_value(initial_witness, outputs[1], res_y);
         Ok(OpcodeResolution::Solved)
     }
 
@@ -134,8 +138,8 @@ impl PartialWitnessGenerator for Barretenberg {
             )
         })?;
 
-        initial_witness.insert(outputs[0], pub_x);
-        initial_witness.insert(outputs[1], pub_y);
+        insert_value(initial_witness, outputs[0], pub_x);
+        insert_value(initial_witness, outputs[1], pub_y);
         Ok(OpcodeResolution::Solved)
     }
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

## Summary\*

This PR updates to target ACVM 0.15.0. I've marked this PR as breaking as it any consumer of this package will need to opt into a breaking change of ACVM.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
