### PR TITLE
fix: Remove wasm32 target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,10 +984,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2642,7 +2640,6 @@ dependencies = [
  "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser",
  "wat",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde-big-array = "0.5.1"
 thiserror = "1.0.21"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Native
 barretenberg-sys = { version = "0.2.0", optional = true }
 
@@ -40,19 +39,10 @@ wasmer = { version = "2.3", optional = true, default-features = false, features 
     "default-universal"
 ] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = [ "js" ] }
-rust-embed = { version = "6.6.0", features = [
-    "debug-embed",
-    "interpolate-folder-path",
-    "include-exclude",
-] }
-wasmer = { version = "2.3", default-features = false, features = [ "js-default" ] }
-
 [build-dependencies]
 pkg-config = "0.3"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[dev-dependencies]
 tokio = { version = "1.0", features = [ "macros" ] }
 
 [features]


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

It seems that `noir_wasm` causes dependency conflicts within this crate when we enable the wasm backend. Removing the wasm32 target from this package allows us to build with the wasm backend again.

Since we aren't going to use this package in the browser, we can just remove this instead of a larger refactoring.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
