### PR TITLE
chore: update to latest barretenberg noir master commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685812470,
-        "narHash": "sha256-sJYVipq1EthnjSxVIZnZF15wy9LDMHNPfIJKRHyZrws=",
+        "lastModified": 1686677483,
+        "narHash": "sha256-mpsCXzHMaqSveQcD/SA9k3NH4pF167KqR5/oYJJjKE8=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "193ce1a45ef5eab6a8522178cf918e45320f3de8",
+        "rev": "65e651d04c6092cb5ca079cd9e12ed9b5846fa3a",
         "type": "github"
       },
       "original": {

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -785,29 +785,38 @@ mod test {
 
     #[test]
     async fn test_memory_constraints() -> Result<(), Error> {
-        let two_field = FieldElement::one() + FieldElement::one();
-        let one = Constraint {
-            a: 0,
+        let a0 = Constraint {
+            a: 2,
             b: 0,
             c: 0,
             qm: FieldElement::zero(),
-            ql: FieldElement::zero(),
-            qr: FieldElement::zero(),
-            qo: FieldElement::zero(),
-            qc: FieldElement::one(),
-        };
-
-        let two_x_constraint = Constraint {
-            a: 1,
-            b: 0,
-            c: 0,
-            qm: FieldElement::zero(),
-            ql: two_field,
+            ql: FieldElement::one(),
             qr: FieldElement::zero(),
             qo: FieldElement::zero(),
             qc: FieldElement::zero(),
         };
-        let x_1_constraint = Constraint {
+        let a1 = Constraint {
+            a: 3,
+            b: 0,
+            c: 0,
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::zero(),
+            qc: FieldElement::zero(),
+        };
+
+        let r1 = Constraint {
+            a: 2,
+            b: 0,
+            c: 0,
+            qm: FieldElement::zero(),
+            ql: FieldElement::one(),
+            qr: FieldElement::zero(),
+            qo: FieldElement::zero(),
+            qc: FieldElement::zero(),
+        };
+        let r2 = Constraint {
             a: 1,
             b: 0,
             c: 0,
@@ -815,7 +824,7 @@ mod test {
             ql: FieldElement::one(),
             qr: FieldElement::zero(),
             qo: FieldElement::zero(),
-            qc: FieldElement::one(),
+            qc: FieldElement::zero(),
         };
 
         let y_constraint = Constraint {
@@ -838,22 +847,24 @@ mod test {
             qo: FieldElement::zero(),
             qc: FieldElement::zero(),
         };
+
         let op1 = MemOpBarretenberg {
-            index: two_x_constraint,
+            index: r1,
             value: y_constraint,
             is_store: 0,
         };
         let op2 = MemOpBarretenberg {
-            index: x_1_constraint.clone(),
+            index: r2.clone(),
             value: z_constraint,
             is_store: 0,
         };
         let block_constraint = BlockConstraint {
-            init: vec![one, x_1_constraint],
+            init: vec![a0, a1],
             trace: vec![op1, op2],
             is_ram: 0,
         };
 
+        let two_field = FieldElement::one() + FieldElement::one();
         let result_constraint = Constraint {
             a: 2,
             b: 3,


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

## Summary\*

This PR updates to use the latest commit on https://github.com/AztecProtocol/barretenberg/pull/499 to show how it breaks the `test_memory_constraints` test. We should fix this before proceeding with #221 

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
