### PR TITLE
feat: add support for atomic memory opcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8e08ddd57e123075a643f9515f712c34ebcfd6333628a4e8972af41f21a694"
+checksum = "bb6315da836487843323dc07343365167ca1c5d9005affa1e412a87b74a98ed6"
 dependencies = [
  "acir_field",
  "bincode",
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729849a0f1ca22f267c83b4d04043f6fa44f159a6606dc58e586c131c67ab774"
+checksum = "7aa14cddc3b16bf9e661d830f7209193b27c1b540f2d2d0249182b6436a963c6"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f1c272779208fe823fe2a327d5e85efb6b8861e858507df4d532ec372514ee"
+checksum = "48bed7a285c69be779c8e07e72e0b146326c4a23a0eaf03725fd089f1337d07c"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee8080267f367360522f24a5cd0de2bf7b9d31795266471c69e352083ceda39"
+checksum = "76b6a5c28ccefa5b6e4162995c7b6e250c5e3ae5109b7e19738ae17a35cb545c"
 dependencies = [
  "acir",
  "blake2",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b52ef8c927058b451576fa7ab7e173c2b302ee81a0337d2420d3ca01c71d5e"
+checksum = "31b5871d78fbaab07689caeb46f7128da17267d6b1775a831339bca86ca22ff0"
 dependencies = [
  "acir",
 ]
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30647da3d1347c3f3a3c0e955f75b1fd3a91c123ee87d6b55d94c042d68e2ae6"
+checksum = "36139e8a7c0bcc1a5d7638a2851d1315d3256777f3c4f713b4ffd0ccd2770e60"
 dependencies = [
  "acir_field",
  "serde",
@@ -406,12 +406,14 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc5c4ce5b6553b4d48f9895ca6b336a3672f1dc802792a37f13dcb8902d47b5"
+checksum = "7a8b61359c74d9c1fd5dbb847a0e4950aa7cb8c2de284ab820f9dcffb6db9fd7"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-acvm = { version = "0.19.0", features = ["bn254"] }
+acvm = { version = "0.20.0", features = ["bn254"] }
 bincode = "1.3.3"
 bytesize = "1.2"
 reqwest = { version = "0.11.16", default-features = false, features = [

--- a/src/acvm_interop/proof_system.rs
+++ b/src/acvm_interop/proof_system.rs
@@ -27,6 +27,8 @@ impl ProofSystemCompiler for Barretenberg {
             Opcode::ROM(_) => true,
             Opcode::RAM(_) => true,
             Opcode::Brillig(_) => true,
+            Opcode::MemoryInit { .. } => true,
+            Opcode::MemoryOp { .. } => true,
             Opcode::BlackBoxFuncCall(func) => match func.get_black_box_func() {
                 BlackBoxFunc::AND
                 | BlackBoxFunc::XOR


### PR DESCRIPTION

# Description

## Problem\*

Add support for new ACIR opcodes for atomic memory operation. They allow ACVM to perform stepwise solving for dynamic memory.

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The backend simply collect these opcode into a block constraint.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
