### PR TITLE
feat!: Update to acvm with mem op predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86577747c44f23e2e8e6d972287d01341c0eea42a78ce15c5efd212a39d0fc27"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir_field",
  "bincode",
@@ -19,8 +18,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4239156a8eddd55b2ae8bd25aa169d012bae70e0fd7c635f08f68ada54a8cb6c"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -33,8 +31,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74351bab6e0fd2ec1bd631abc73260f374cc28d2baf85c0e11300c0c989d5e53"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -69,8 +66,7 @@ dependencies = [
 [[package]]
 name = "acvm_blackbox_solver"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a362499180c6498acc0ebf77bd919be8ccd9adabc84a695d4af44ca180ba0709"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir",
  "blake2",
@@ -84,8 +80,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e485b3bc3331eaa10bc92fb092ca14275936c8935c3ae7ec89fb0bd48246ab42"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir",
 ]
@@ -402,8 +397,7 @@ dependencies = [
 [[package]]
 name = "brillig"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64df3df7d2d96fc2519e4dd64bc6bc23eee2949ee86725d9041ef7703c283ab"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir_field",
  "serde",
@@ -412,8 +406,7 @@ dependencies = [
 [[package]]
 name = "brillig_vm"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b306b3d79b6da192fd2ed68b94ab07712496f39bb5d50fedce44dac3f4953065"
+source = "git+https://github.com/noir-lang/acvm.git?rev=4b4e8a6a25b27e82bddbfe58caa3d421285b4a82#4b4e8a6a25b27e82bddbfe58caa3d421285b4a82"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ tokio = { version = "1.0", features = ["macros"] }
 default = ["native"]
 native = ["dep:barretenberg-sys"]
 wasm = ["dep:wasmer", "dep:rust-embed", "dep:getrandom"]
+
+[patch.crates-io]
+acvm = { git = "https://github.com/noir-lang/acvm.git", rev = "4b4e8a6a25b27e82bddbfe58caa3d421285b4a82" }

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -1313,7 +1313,7 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                 Opcode::Directive(_) | Opcode::Brillig(_) => {
                     // Directives, Oracles and Brillig are only needed by the pwg
                 }
-                Opcode::MemoryOp { block_id, op } => {
+                Opcode::MemoryOp { block_id, op, predicate: _ } => {
                     let block = blocks
                         .get_mut(&block_id.0)
                         .expect("memory operation on an uninitialized block");

--- a/src/barretenberg_structures.rs
+++ b/src/barretenberg_structures.rs
@@ -1313,7 +1313,11 @@ impl TryFrom<&Circuit> for ConstraintSystem {
                 Opcode::Directive(_) | Opcode::Brillig(_) => {
                     // Directives, Oracles and Brillig are only needed by the pwg
                 }
-                Opcode::MemoryOp { block_id, op, predicate: _ } => {
+                Opcode::MemoryOp {
+                    block_id,
+                    op,
+                    predicate: _,
+                } => {
                     let block = blocks
                         .get_mut(&block_id.0)
                         .expect("memory operation on an uninitialized block");


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

In order to upstream the changes in ACVM (https://github.com/noir-lang/acvm/pull/503) to Noir we need to update the barretenberg structures in this repo.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
