### PR TITLE
chore: build barretenberg from stable release tag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,15 +10,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1688820427,
-        "narHash": "sha256-w7yMeYp50KrlTn23TTKfYmLOQL4uIgw0wSX67v2tvvc=",
+        "lastModified": 1692806910,
+        "narHash": "sha256-VlxTpIqNFtpDKAwqAI812pnBDD7lI/g5lQWDiPDb9jE=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "fdd46f77531a6fcc9d9b24a698c56590d54d487e",
+        "rev": "b42bb32db019717aa37bb2f1404d081cc9969202",
         "type": "github"
       },
       "original": {
         "owner": "AztecProtocol",
+        "ref": "barretenberg-v0.4.3",
         "repo": "barretenberg",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
     };
 
     barretenberg = {
-      url = "github:AztecProtocol/barretenberg";
+      url = "github:AztecProtocol/barretenberg?ref=barretenberg-v0.4.3";
       # All of these inputs (a.k.a. dependencies) need to align with inputs we
       # use so they use the `inputs.*.follows` syntax to reference our inputs
       inputs = {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves #243 

## Summary\*

This PR updates the nix flake to build barretenberg from the stable release tag which we use for downloading `bb`.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
