### PR TITLE
chore(ci): create cache entries even if tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      CACHED_PATH: /tmp/nix-cache
 
     strategy:
       fail-fast: false
@@ -35,20 +38,20 @@ jobs:
           name: barretenberg
 
       - name: Restore nix store cache
-        id: nix-store-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
+        id: cache
         with:
-          path: /tmp/nix-cache
+          path: ${{ env.CACHED_PATH }}
           key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
 
       # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store
-        if: steps.nix-store-cache.outputs.cache-hit == 'true'
+        if: steps.cache.outputs.cache-hit == 'true'
         # We don't check the signature because we're the one that created the cache
         run: |
-          for narinfo in /tmp/nix-cache/*.narinfo; do
+          for narinfo in ${{ env.CACHED_PATH }}/*.narinfo; do
             path=$(head -n 1 "$narinfo" | awk '{print $2}')
-            nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
+            nix copy --no-check-sigs --from "file://${{ env.CACHED_PATH }}" "$path"
           done
 
       - name: Run `nix flake check`
@@ -56,7 +59,14 @@ jobs:
           nix flake check -L
 
       - name: Export cache from nix store
-        if: steps.nix-store-cache.outputs.cache-hit != 'true'
+        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' }}
         run: |
           nix copy --to "file:///tmp/nix-cache?compression=zstd&parallel-compression=true" .#native-cargo-artifacts
           nix copy --to "file:///tmp/nix-cache?compression=zstd&parallel-compression=true" .#wasm-cargo-artifacts
+
+      - uses: actions/cache/save@v3
+        # Write a cache entry even if the tests fail but don't create any for the merge queue.
+        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' }}
+        with:
+          path: ${{ env.CACHED_PATH }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       CACHED_PATH: /tmp/nix-cache
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates how we handle caches to be closer to how we do it in the main repository, cache entries are created even if the tests fail.

A timeout of 30 minutes is also added.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
